### PR TITLE
fehler meldung korrigiert

### DIFF
--- a/src/routes/lotn/sheet/create/step_01/+page.svelte
+++ b/src/routes/lotn/sheet/create/step_01/+page.svelte
@@ -145,6 +145,15 @@
 			return store;
 		});
 	}
+
+	function updateName(event: Event) {
+		const target = event.target as HTMLInputElement;
+		characterCreationStore.update((store) => {
+			const value = target.value.trim();
+			store.name = value.length <= 0 ? undefined : value;
+			return store;
+		});
+	}
 </script>
 
 <label class="label">
@@ -154,7 +163,8 @@
 		class="input variant-form-material"
 		placeholder="Select a name for your character"
 		type="text"
-		bind:value={$characterCreationStore.name}
+		value={$characterCreationStore.name ?? ''}
+		on:change={updateName}
 	/>
 </label>
 

--- a/src/routes/lotn/sheet/create/step_11/+page.svelte
+++ b/src/routes/lotn/sheet/create/step_11/+page.svelte
@@ -38,6 +38,27 @@
 		}
 		submitting = false;
 	}
+
+	function validCharacter() {
+		const result = playerCharacter.safeParse($characterCreationStore);
+		if (result.success) {
+			return true;
+		} else {
+			const errors = result.error?.errors;
+			return errors.length === 1 && errors[0].path.length === 1 && errors[0].path[0] === 'id'
+				? true
+				: false;
+		}
+	}
+
+	function getErrorMessages() {
+		const result = playerCharacter.safeParse($characterCreationStore);
+		if (result.success) {
+			return [];
+		} else {
+			return result.error?.errors.filter((e) => e.path[0] !== 'id') ?? [];
+		}
+	}
 </script>
 
 <div class="grid grid-cols-1 grid-rows-1 gap-2 sm:grid-cols-3">
@@ -68,7 +89,7 @@
 	</HelpText>
 </div>
 
-{#if playerCharacter.safeParse($characterCreationStore).success}
+{#if validCharacter()}
 	<aside class="alert variant-filled-success col-span-2 mt-4 rounded-lg">
 		<div>
 			<iconify-icon height="48" icon="mdi:success" />
@@ -112,9 +133,7 @@
 		<div class="alert-message">
 			<h3 class="h3">The character is invalid</h3>
 			<p>There are some formal validation errors with the character.</p>
-			{#each playerCharacter
-				.safeParse($characterCreationStore)
-				.error?.errors.filter((e) => !e.path.includes('id')) ?? [] as error}
+			{#each getErrorMessages() as error}
 				<p>{error.path}: {error.message}</p>
 			{/each}
 		</div>


### PR DESCRIPTION
- beim update des Namens wird jetzt getrimmed
- die Prüfung auf Fehler auf der letzten Seitze wurde korrigiert: der letzte Fehler ("id" fehlt) führt nicht mehr dazu, dass eine leere Fehlermeldung angezeigt wird