### PR TITLE
mobile-menü und buttons verbessert

### DIFF
--- a/src/lib/components/SidebarMenu/SidebarMenu.svelte
+++ b/src/lib/components/SidebarMenu/SidebarMenu.svelte
@@ -31,7 +31,7 @@
 {#if $isMenuOpen}
 	<aside
 		bind:this={sidebarRef}
-		class="fixed inset-y-0 left-0 z-10 w-64 bg-gray-400 p-4 text-white dark:bg-gray-700"
+		class="fixed inset-y-0 left-0 z-10 w-64 overflow-scroll bg-gray-400 p-4 text-white dark:bg-gray-700"
 	>
 		<nav>
 			{#if loggedIn}

--- a/src/routes/lotn/sheet/create/step_02/+page.svelte
+++ b/src/routes/lotn/sheet/create/step_02/+page.svelte
@@ -28,7 +28,7 @@
 <svelte:window bind:innerWidth />
 
 <div class="mt-2 grid gap-4 sm:grid-cols-[auto_2fr]">
-	<div class="grid auto-rows-auto grid-cols-3 gap-2 sm:flex sm:flex-col">
+	<div class="grid auto-rows-auto grid-cols-2 gap-2 sm:flex sm:flex-col">
 		{#each clanName.options as clanNameEntry}
 			<button
 				class={`variant-filled-primary btn rounded-lg ${$characterCreationStore.clan === clanNameEntry ? 'ring-2 ring-black dark:ring-white' : ''}`}

--- a/src/routes/lotn/sheet/create/step_06/+page.svelte
+++ b/src/routes/lotn/sheet/create/step_06/+page.svelte
@@ -196,7 +196,7 @@
 
 <div class="mt-2 grid grid-cols-1 gap-4 sm:grid-cols-[auto_2fr]">
 	{#if !get(characterCreationStore).ghoul}
-		<div class="grid auto-rows-auto grid-cols-3 gap-2 sm:grid-cols-1">
+		<div class="grid auto-rows-auto grid-cols-2 gap-2 sm:grid-cols-1">
 			{#each getValidPredatorTypes() as predatorTypeEntry}
 				<button
 					class={`variant-filled-primary btn rounded-lg ${$characterCreationStore.predatorType === predatorTypeEntry ? 'ring-2 ring-black dark:ring-white' : ''}`}

--- a/src/routes/lotn/sheet/create/step_10/+page.svelte
+++ b/src/routes/lotn/sheet/create/step_10/+page.svelte
@@ -1332,10 +1332,10 @@
 
 <svelte:window bind:innerWidth />
 
-<div class="grid grid-cols-2 grid-rows-2 gap-2 sm:grid-cols-3 sm:grid-rows-1">
+<div class="grid auto-rows-auto grid-cols-1 gap-2 sm:grid-cols-2 xl:grid-cols-3">
 	<Tracker title="Experience Total" value={xpGained} />
 	<Tracker title="Experience Spent" value={xpSpent} />
-	<div class="col-span-2 sm:col-span-1">
+	<div class="sm:col-span-2 xl:col-span-1">
 		<Tracker title="Experience Left" value={xpLeft} />
 	</div>
 </div>


### PR DESCRIPTION
- das aufklapp menü aus der mobile ansicht ist jetzt scrollbar
- buttons bei clans und predatortype auswahl ist jetzt auf kleineren Bildschirmen zweispaltig (statt dreispaltig)
- Die drei EXP-Anzeigen sind jetzt auf kleinen Bildschirmen untereinander angezeigt statt nebeneinander um einen Overflow des Textes zu verhindern