### PR TITLE
Zwischenspeichern in localStorage, Merits/Flaws direkt editierbar und Linguistics 0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"@tailwindcss/forms": "^0.5.9",
 		"@tailwindcss/typography": "^0.5.15",
 		"@types/eslint__js": "^8.42.3",
+		"@types/lodash": "^4.17.15",
 		"@types/node": "^20.17.6",
 		"@typescript-eslint/eslint-plugin": "^7.18.0",
 		"@typescript-eslint/parser": "^7.18.0",
@@ -52,5 +53,8 @@
 		"zod": "^3.23.8"
 	},
 	"type": "module",
-	"packageManager": "pnpm@9.1.3+sha512.7c2ea089e1a6af306409c4fc8c4f0897bdac32b772016196c469d9428f1fe2d5a21daf8ad6512762654ac645b5d9136bb210ec9a00afa8dbc4677843ba362ecd"
+	"packageManager": "pnpm@9.1.3+sha512.7c2ea089e1a6af306409c4fc8c4f0897bdac32b772016196c469d9428f1fe2d5a21daf8ad6512762654ac645b5d9136bb210ec9a00afa8dbc4677843ba362ecd",
+	"dependencies": {
+		"lodash": "^4.17.21"
+	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
     devDependencies:
       '@eslint/js':
         specifier: ^9.14.0
@@ -41,6 +45,9 @@ importers:
       '@types/eslint__js':
         specifier: ^8.42.3
         version: 8.42.3
+      '@types/lodash':
+        specifier: ^4.17.15
+        version: 4.17.15
       '@types/node':
         specifier: ^20.17.6
         version: 20.17.6
@@ -540,6 +547,9 @@ packages:
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/lodash@4.17.15':
+    resolution: {integrity: sha512-w/P33JFeySuhN6JLkysYUK2gEmy9kHHFN7E8ro0tkfmlDOgxBDzWEZ/J8cWA+fHqFevpswDTFZnDx+R9lbL6xw==}
 
   '@types/node@20.17.6':
     resolution: {integrity: sha512-VEI7OdvK2wP7XHnsuXbAJnEpEkF6NjSN45QJlL4VGqZSXsnicpesdTWsg9RISeSdYd3yeRj/y3k5KGjUXYnFwQ==}
@@ -1406,6 +1416,9 @@ packages:
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
@@ -2598,6 +2611,8 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
+  '@types/lodash@4.17.15': {}
+
   '@types/node@20.17.6':
     dependencies:
       undici-types: 6.19.8
@@ -3615,6 +3630,8 @@ snapshots:
   lodash.isplainobject@4.0.6: {}
 
   lodash.merge@4.6.2: {}
+
+  lodash@4.17.21: {}
 
   loupe@2.3.7:
     dependencies:

--- a/src/lib/components/lotn/EditableMerit/EditableMerit.svelte
+++ b/src/lib/components/lotn/EditableMerit/EditableMerit.svelte
@@ -16,7 +16,7 @@
 	export let showDescriptionInput: boolean = false;
 	export let enableEditValue: boolean = false;
 	export let enableEditLinkedSkill: boolean = false;
-	export let minValue: number = 1;
+	export let startValue: number = 1;
 
 	const config = meritConfig[merit.name];
 
@@ -28,7 +28,13 @@
 	}>();
 
 	function iconClick(event: CustomEvent<{ index: number }>) {
-		if (event.detail.index > minValue) {
+		const maxValue = meritConfig[merit.name]?.max ?? 5;
+
+		if (event.detail.index > maxValue) {
+			event.detail.index = maxValue;
+		}
+
+		if (event.detail.index > startValue) {
 			return dispatchChange('valueChange', {
 				id: merit.id,
 				label: merit.name,
@@ -39,111 +45,118 @@
 		return dispatchChange('valueChange', {
 			id: merit.id,
 			label: merit.name,
-			value: minValue
+			value: startValue
 		});
 	}
 </script>
 
 <label
-	class={`card grid w-full auto-rows-auto grid-cols-1 rounded-lg p-4`}
+	class={`row card grid w-full grid-cols-1 grid-rows-[min-content] rounded-lg p-2`}
 	for={`${merit.name}-${merit.id}`}
 >
-	<div class={`label flex flex-wrap ${displayFormat === 'row' ? 'flex-row gap-x-2' : 'flex-col'}`}>
-		<div class="flex justify-between">
-			{#if config && config.prerequisite}
-				<HelpText id={`${merit.name}-${merit.id}`} placement="bottom-start">
-					<span id={`${merit.name}-${merit.id}`} class="whitespace-nowrap">{merit.name}</span>
-					<svelte:fragment slot="helpText">
-						{#if config && config.prerequisite}
+	<div class="flex justify-between gap-x-4">
+		<div
+			class={`label flex flex-wrap ${displayFormat === 'row' ? 'w-full flex-row justify-between' : 'flex-col'}`}
+		>
+			<div class="w-fit">
+				{#if config && config.prerequisite}
+					<HelpText id={`${merit.name}-${merit.id}`} placement="bottom-start">
+						<span id={`${merit.name}-${merit.id}`} class="whitespace-nowrap">{merit.name}</span>
+						<svelte:fragment slot="helpText">
+							{#if config && config.prerequisite}
+								<p class="whitespace-pre-line">
+									<span class="font-bold">Prerequisite:</span>
+									{#if Array.isArray(config.prerequisite)}
+										{#each config.prerequisite as prerequisite}
+											{#if typeof prerequisite === 'string'}
+												{prerequisite}
+											{:else}
+												{prerequisite.name}
+												{prerequisite.value}
+											{/if}
+										{/each}
+									{:else if typeof config.prerequisite === 'string'}
+										{config.prerequisite}
+									{:else}
+										{config.prerequisite.name}
+										{config.prerequisite.value}
+									{/if}
+								</p>
+							{/if}
+						</svelte:fragment>
+					</HelpText>
+				{:else if config}
+					<HelpText id={`${merit.name}-${merit.id}`} placement="bottom-start">
+						<span id={`${merit.name}-${merit.id}`} class="whitespace-nowrap">{merit.name}</span>
+						<svelte:fragment slot="helpText">
 							<p class="whitespace-pre-line">
-								<span class="font-bold">Prerequisite:</span>
-								{#if Array.isArray(config.prerequisite)}
-									{#each config.prerequisite as prerequisite}
-										{#if typeof prerequisite === 'string'}
-											{prerequisite}
-										{:else}
-											{prerequisite.name}
-											{prerequisite.value}
-										{/if}
-									{/each}
-								{:else if typeof config.prerequisite === 'string'}
-									{config.prerequisite}
-								{:else}
-									{config.prerequisite.name}
-									{config.prerequisite.value}
-								{/if}
+								{getMeritValueDescription(merit.name, merit.value)}
 							</p>
-						{/if}
-					</svelte:fragment>
-				</HelpText>
-			{:else if config}
-				<HelpText id={`${merit.name}-${merit.id}`} placement="bottom-start">
+						</svelte:fragment>
+					</HelpText>
+				{:else}
 					<span id={`${merit.name}-${merit.id}`} class="whitespace-nowrap">{merit.name}</span>
-					<svelte:fragment slot="helpText">
-						<p class="whitespace-pre-line">
-							{getMeritValueDescription(merit.name, merit.value)}
-						</p>
-					</svelte:fragment>
-				</HelpText>
-			{:else}
-				<span id={`${merit.name}-${merit.id}`} class="whitespace-nowrap">{merit.name}</span>
-			{/if}
-			{#if showDeleteButton}
-				<button
-					class="variant-filled-primary btn w-4 justify-self-end rounded-lg text-sm"
-					disabled={disableDeleteButton}
-					type="button"
-					on:click={() => {
-						dispatchChange('deleteClick', { id: merit.id });
-					}}
-				>
-					<iconify-icon height="16" icon="mdi:remove" />
-				</button>
-			{/if}
+				{/if}
+			</div>
+			<div>
+				{#if !enableEditValue}
+					<HelpText id={`${merit.name}-${merit.id}-value`}>
+						<Ratings
+							id={`${merit.name}-${merit.id}-value`}
+							interactive={$interactiveModeStore}
+							justify="justify-left"
+							bind:value={merit.value}
+						>
+							<svelte:fragment slot="empty">
+								<iconify-icon icon="prime:circle" />
+							</svelte:fragment>
+							<svelte:fragment slot="full">
+								<iconify-icon icon="prime:circle-fill" />
+							</svelte:fragment>
+						</Ratings>
+						<svelte:fragment slot="helpText">
+							<p class="whitespace-pre-line">
+								{getMeritValueDescription(merit.name, merit.value)}
+							</p>
+						</svelte:fragment>
+					</HelpText>
+				{:else}
+					<Ratings
+						id={`${merit.name}-${merit.id}-value`}
+						interactive={true}
+						justify="justify-left"
+						max={5}
+						value={merit.value}
+						on:icon={iconClick}
+					>
+						<svelte:fragment slot="empty">
+							<iconify-icon icon="prime:circle" />
+						</svelte:fragment>
+						<svelte:fragment slot="full">
+							<iconify-icon icon="prime:circle-fill" />
+						</svelte:fragment>
+					</Ratings>
+				{/if}
+			</div>
 		</div>
-		{#if merit.value > 0 && !enableEditValue}
-			<HelpText id={`${merit.name}-${merit.id}-value`}>
-				<Ratings
-					id={`${merit.name}-${merit.id}-value`}
-					interactive={$interactiveModeStore}
-					justify="justify-left"
-					bind:value={merit.value}
-				>
-					<svelte:fragment slot="empty">
-						<iconify-icon icon="prime:circle" />
-					</svelte:fragment>
-					<svelte:fragment slot="full">
-						<iconify-icon icon="prime:circle-fill" />
-					</svelte:fragment>
-				</Ratings>
-				<svelte:fragment slot="helpText">
-					<p class="whitespace-pre-line">
-						{getMeritValueDescription(merit.name, merit.value)}
-					</p>
-				</svelte:fragment>
-			</HelpText>
-		{:else if merit.value > 0}
-			<Ratings
-				id={`${merit.name}-${merit.id}-value`}
-				interactive={true}
-				justify="justify-left"
-				max={5}
-				value={merit.value}
-				on:icon={iconClick}
+		{#if showDeleteButton}
+			<button
+				class="variant-filled-primary btn max-h-8 max-w-8 justify-self-end rounded-lg text-sm"
+				disabled={disableDeleteButton}
+				type="button"
+				on:click={() => {
+					dispatchChange('deleteClick', { id: merit.id });
+				}}
 			>
-				<svelte:fragment slot="empty">
-					<iconify-icon style="vertical-align: -0.225em" icon="prime:circle" />
-				</svelte:fragment>
-				<svelte:fragment slot="full">
-					<iconify-icon style="vertical-align: -0.225em" icon="prime:circle-fill" />
-				</svelte:fragment>
-			</Ratings>
+				<iconify-icon height="16" icon="mdi:remove" />
+			</button>
 		{/if}
 	</div>
 	{#if showDescriptionInput}
-		<input
-			class="input variant-form-material mt-2"
-			type="text"
+		<textarea
+			class="textarea variant-form-material mt-2"
+			maxlength="100"
+			rows="1"
 			bind:value={merit.description}
 			on:change={() => {
 				dispatchChange('descriptionChange', { id: merit.id, description: merit.description });
@@ -157,7 +170,7 @@
 	{#if meritHasLinkedSkills(merit)}
 		{#if enableEditLinkedSkill}
 			<select
-				class="select mt-2 rounded-lg"
+				class="select mt-2 max-h-fit rounded-lg"
 				bind:value={merit.linkedSkill}
 				on:change={() =>
 					dispatchChange('linkedSkillChange', { id: merit.id, linkedSkill: merit.linkedSkill })}

--- a/src/lib/components/lotn/EditableSkill/EditableSkill.svelte
+++ b/src/lib/components/lotn/EditableSkill/EditableSkill.svelte
@@ -29,7 +29,7 @@
 </script>
 
 <div class="card rounded-lg">
-	<header class="card-header pb-4">
+	<header class="card-header p-2">
 		<div class="grid grid-cols-[1fr_auto] gap-2">
 			{#if displayValue === 'below'}
 				<div class="flex flex-col">
@@ -137,7 +137,7 @@
 			{/if}
 			{#if showDeleteButton}
 				<button
-					class="variant-filled-primary btn ml-auto w-3 rounded-lg"
+					class="variant-filled-primary btn ml-auto max-h-8 max-w-8 rounded-lg"
 					type="button"
 					on:click={() => dispatchChange('deleteChange', { label: skill.name })}
 				>
@@ -154,6 +154,7 @@
 							id="name"
 							class="input variant-form-material"
 							disabled={!editModeEnabled}
+							maxlength="30"
 							type="text"
 							value={skill.specialization ?? ''}
 							on:blur={(event) =>

--- a/src/lib/components/lotn/util/flawUtil.ts
+++ b/src/lib/components/lotn/util/flawUtil.ts
@@ -1,3 +1,4 @@
+import { flawPaymentStore } from '$lib/stores/flawPaymentStore';
 import type { FlawName } from '$lib/zod/lotn/enums/flawName';
 import { flawConfig } from '../config/flawsConfig';
 import { createNumberList } from './generalUtils';
@@ -17,6 +18,20 @@ export function getApplicableFlawLevels(flawName: FlawName) {
 		if ('level5' in config) numberList.push(5);
 		return numberList;
 	}
+}
+
+export function hasMultipleFlawLevels(flawName: FlawName) {
+	return getApplicableFlawLevels(flawName).length > 1;
+}
+
+export function getMinFlawLevel(flawName: FlawName) {
+	const numbersList = getApplicableFlawLevels(flawName);
+	return Math.min(...numbersList);
+}
+
+export function getMaxFlawLevel(flawName: FlawName) {
+	const numbersList = getApplicableFlawLevels(flawName);
+	return Math.max(...numbersList);
 }
 
 export function getFlawValueDescription(flawName: FlawName, value: number) {
@@ -73,4 +88,9 @@ export function isThinBloodFlaw(flawName: FlawName) {
 	if (!config) return false;
 
 	return config.category === 'Thin-Blood';
+}
+
+export function getFlawsTotal() {
+	const chosenFlaws = flawPaymentStore.getChosenFlaws();
+	return chosenFlaws.reduce((acc, flaw) => acc + flaw.freebies, 0);
 }

--- a/src/lib/stores/attributesPaidWithDotsStore.ts
+++ b/src/lib/stores/attributesPaidWithDotsStore.ts
@@ -14,11 +14,41 @@ export class AttributesPaidWithDotsStore {
 
 	private _attributesPaidWithDotsStoreInternal: Writable<AttributesPaidWithDotsStoreEntrySchema> =
 		writable(cloneDeep(this._defaultValues));
+	private unsubscribe: () => void;
+
+	constructor() {
+		let initialValue: AttributesPaidWithDotsStoreEntrySchema;
+
+		if (typeof localStorage !== 'undefined') {
+			const storedValue = localStorage.getItem('attributesPaidWithDotsStore');
+			initialValue = storedValue ? JSON.parse(storedValue) : cloneDeep(this._defaultValues);
+		} else {
+			initialValue = cloneDeep(this._defaultValues);
+		}
+
+		this._attributesPaidWithDotsStoreInternal.set(initialValue);
+
+		if (typeof localStorage !== 'undefined') {
+			this.unsubscribe = this._attributesPaidWithDotsStoreInternal.subscribe((value) => {
+				localStorage.setItem('attributesPaidWithDotsStore', JSON.stringify(value));
+			});
+		} else {
+			this.unsubscribe = () => {};
+		}
+	}
+
+	destroy() {
+		this.unsubscribe();
+	}
 
 	subscribe = this._attributesPaidWithDotsStoreInternal.subscribe;
 
 	get store() {
 		return get(this._attributesPaidWithDotsStoreInternal);
+	}
+
+	reset() {
+		this._attributesPaidWithDotsStoreInternal.set(cloneDeep(this._defaultValues));
 	}
 
 	set attributePaidWithDots(value: { dots: AttributeDotCategory; attributeName: AttributeName }) {
@@ -94,10 +124,6 @@ export class AttributesPaidWithDotsStore {
 			return true;
 		}
 		return false;
-	}
-
-	reset() {
-		this._attributesPaidWithDotsStoreInternal.set(cloneDeep(this._defaultValues));
 	}
 
 	sortAttributeNames(index: number) {

--- a/src/lib/stores/characterCreationStore.ts
+++ b/src/lib/stores/characterCreationStore.ts
@@ -8,17 +8,15 @@ import {
 import { backgroundName, type BackgroundName } from '$lib/zod/lotn/enums/backgroundName';
 import type { SpheresOfInfluenceName } from '$lib/zod/lotn/enums/spheresOfInfluenceName';
 import type { PlayerBackgroundAdvantage } from '$lib/zod/lotn/playerCharacter/playerBackgroundAdvantage';
-import {
-	playerCharacterCreate,
-	type PlayerCharacterCreate
-} from '$lib/zod/lotn/playerCharacter/playerCharacter';
+import { playerCharacterCreate } from '$lib/zod/lotn/playerCharacter/playerCharacter';
 import type { AssociatedAdvantage } from '$lib/zod/lotn/types/loresheetSchema';
 import { derived, get, writable, type Readable, type Writable } from 'svelte/store';
 import { z } from 'zod';
+import { localStorageStore } from './localStorageStore';
 
-export const characterCreationStore: Writable<PlayerCharacterCreate> = writable(
-	playerCharacterCreate.parse({})
-);
+export const initialCharacterStoreObject = Object.freeze(playerCharacterCreate.parse({}));
+
+export const characterCreationStore = localStorageStore('characterCreationStore');
 
 const paymentStoreEntrySchema = z.object({
 	predator: z.number(),
@@ -89,6 +87,15 @@ export class BackgroundPaymentStore {
 	private _usedFreebiePointsInternal: Readable<number>;
 	private _maxFreebiePointsInternal: Readable<number>;
 	private _paymentStoreInternal: Writable<PaymentStoreSchema>;
+
+	reset() {
+		this._usedFreebiePointsInternal = writable(0);
+		this._paymentStoreInternal.set({
+			backgrounds: [],
+			associatedAdvantage: [],
+			loresheet: []
+		});
+	}
 
 	get usedFreebiePoints() {
 		return this._usedFreebiePointsInternal;

--- a/src/lib/stores/flawPaymentStore.ts
+++ b/src/lib/stores/flawPaymentStore.ts
@@ -13,6 +13,11 @@ export class FlawPaymentStore {
 	_flawStoreInternal: Writable<FlawPaymentStoreEntrySchema[]>;
 	_mythicalCounter: Writable<number> = writable(0);
 
+	reset() {
+		this._flawStoreInternal.set([]);
+		this._mythicalCounter.set(0);
+	}
+
 	addPredatorFlaw(name: FlawName, value: number, hasPredeterminedDescription: boolean = false) {
 		const id = generateId();
 		this._flawStoreInternal.update((store) => {

--- a/src/lib/stores/flawPaymentStore.ts
+++ b/src/lib/stores/flawPaymentStore.ts
@@ -1,21 +1,80 @@
 import { flawConfig } from '$lib/components/lotn/config/flawsConfig';
 import { generateId } from '$lib/util';
 import { type FlawName, flawName } from '$lib/zod/lotn/enums/flawName';
+import cloneDeep from 'lodash/cloneDeep';
 import { get, type Writable, writable } from 'svelte/store';
 import { z } from 'zod';
 import { characterCreationStore } from './characterCreationStore';
 
 export class FlawPaymentStore {
+	private _initialFlawStoreValues: FlawPaymentStoreEntrySchema[] = [];
+	_flawStoreInternal: Writable<FlawPaymentStoreEntrySchema[]> = writable(
+		cloneDeep(this._initialFlawStoreValues)
+	);
+	private unsubscribeFlawPaymentStore: () => void;
+
+	private _initialMythicalCounterValue = 0;
+	_mythicalCounterStoreInternal: Writable<number> = writable(
+		cloneDeep(this._initialMythicalCounterValue)
+	);
+	private unsubscribeMythicalCounterStore: () => void;
+
 	constructor() {
-		this._flawStoreInternal = writable(flawPaymentStoreEntrySchema.array().parse([]));
+		// Flaw Store
+		let initialValueFlawPaymentStore: FlawPaymentStoreEntrySchema[];
+
+		if (typeof localStorage !== 'undefined') {
+			const storedValue = localStorage.getItem('flawPaymentStore');
+			initialValueFlawPaymentStore = storedValue
+				? JSON.parse(storedValue)
+				: cloneDeep(this._initialFlawStoreValues);
+		} else {
+			initialValueFlawPaymentStore = cloneDeep(this._initialFlawStoreValues);
+		}
+
+		this._flawStoreInternal.set(initialValueFlawPaymentStore);
+
+		if (typeof localStorage !== 'undefined') {
+			this.unsubscribeFlawPaymentStore = this._flawStoreInternal.subscribe((value) => {
+				localStorage.setItem('flawPaymentStore', JSON.stringify(value));
+			});
+		} else {
+			this.unsubscribeFlawPaymentStore = () => {};
+		}
+
+		// Mythical Counter Store
+		let initialValueMythicalCounterStore: number;
+
+		if (typeof localStorage !== 'undefined') {
+			const storedValue = localStorage.getItem('mythicalCounterStore');
+			initialValueMythicalCounterStore = storedValue
+				? JSON.parse(storedValue)
+				: cloneDeep(this._initialMythicalCounterValue);
+		} else {
+			initialValueMythicalCounterStore = cloneDeep(this._initialMythicalCounterValue);
+		}
+
+		this._mythicalCounterStoreInternal.set(initialValueMythicalCounterStore);
+
+		if (typeof localStorage !== 'undefined') {
+			this.unsubscribeMythicalCounterStore = this._mythicalCounterStoreInternal.subscribe(
+				(value) => {
+					localStorage.setItem('mythicalCounterStore', JSON.stringify(value));
+				}
+			);
+		} else {
+			this.unsubscribeMythicalCounterStore = () => {};
+		}
 	}
 
-	_flawStoreInternal: Writable<FlawPaymentStoreEntrySchema[]>;
-	_mythicalCounter: Writable<number> = writable(0);
+	destroy() {
+		this.unsubscribeFlawPaymentStore();
+		this.unsubscribeMythicalCounterStore();
+	}
 
 	reset() {
-		this._flawStoreInternal.set([]);
-		this._mythicalCounter.set(0);
+		this._flawStoreInternal.set(cloneDeep(this._initialFlawStoreValues));
+		this._mythicalCounterStoreInternal.set(0);
 	}
 
 	addPredatorFlaw(name: FlawName, value: number, hasPredeterminedDescription: boolean = false) {
@@ -70,11 +129,11 @@ export class FlawPaymentStore {
 	}
 
 	addRequiredMythicalFlaws(value: number) {
-		this._mythicalCounter.update((store) => store + value);
+		this._mythicalCounterStoreInternal.update((store) => store + value);
 	}
 
 	getRequiredMythicalFlaws() {
-		return get(this._mythicalCounter);
+		return get(this._mythicalCounterStoreInternal);
 	}
 
 	getPredatorFlaws() {
@@ -91,7 +150,7 @@ export class FlawPaymentStore {
 		const flawsToDelete = this.getPredatorFlaws();
 		const deleteIds = flawsToDelete.map((flaw) => flaw.id);
 
-		this._mythicalCounter.update((store) => {
+		this._mythicalCounterStoreInternal.update((store) => {
 			store = 0;
 			return store;
 		});

--- a/src/lib/stores/localStorageCharacterCreationStore.ts
+++ b/src/lib/stores/localStorageCharacterCreationStore.ts
@@ -7,7 +7,7 @@ import { backgroundPaymentStore, initialCharacterStoreObject } from './character
 import { flawPaymentStore } from './flawPaymentStore';
 import { meritPaymentStore } from './meritPaymentStore';
 
-export function localStorageStore(
+export function localStorageCharacterCreationStore(
 	key: string
 ): Writable<PlayerCharacterCreate> & { clear: () => void } {
 	let storedValue: PlayerCharacterCreate;

--- a/src/lib/stores/localStorageCharacterCreationStore.ts
+++ b/src/lib/stores/localStorageCharacterCreationStore.ts
@@ -6,6 +6,7 @@ import { attributesPaidWithDotsStore } from './attributesPaidWithDotsStore';
 import { backgroundPaymentStore, initialCharacterStoreObject } from './characterCreationStore';
 import { flawPaymentStore } from './flawPaymentStore';
 import { meritPaymentStore } from './meritPaymentStore';
+import { skillsPaidWithDotsStore } from './skillsPaidWithDotsStore';
 
 export function localStorageCharacterCreationStore(
 	key: string
@@ -41,6 +42,7 @@ export function localStorageCharacterCreationStore(
 				return store;
 			});
 			attributesPaidWithDotsStore.reset();
+			skillsPaidWithDotsStore.reset();
 			backgroundPaymentStore.reset();
 			meritPaymentStore.reset();
 			flawPaymentStore.reset();

--- a/src/lib/stores/localStorageStore.ts
+++ b/src/lib/stores/localStorageStore.ts
@@ -1,0 +1,49 @@
+import { generateId } from '$lib/util';
+import type { PlayerCharacterCreate } from '$lib/zod/lotn/playerCharacter/playerCharacter';
+import cloneDeep from 'lodash/cloneDeep';
+import { writable, type Writable } from 'svelte/store';
+import { attributesPaidWithDotsStore } from './attributesPaidWithDotsStore';
+import { backgroundPaymentStore, initialCharacterStoreObject } from './characterCreationStore';
+import { flawPaymentStore } from './flawPaymentStore';
+import { meritPaymentStore } from './meritPaymentStore';
+
+export function localStorageStore(
+	key: string
+): Writable<PlayerCharacterCreate> & { clear: () => void } {
+	let storedValue: PlayerCharacterCreate;
+
+	if (typeof localStorage !== 'undefined') {
+		const item = localStorage.getItem(key);
+		storedValue = item ? JSON.parse(item) : cloneDeep(initialCharacterStoreObject);
+	} else {
+		storedValue = cloneDeep(initialCharacterStoreObject);
+	}
+
+	const store = writable<PlayerCharacterCreate>(storedValue);
+
+	if (typeof localStorage !== 'undefined') {
+		store.subscribe((value) => {
+			localStorage.setItem(key, JSON.stringify(value));
+		});
+	}
+
+	return {
+		...store,
+		clear: () => {
+			if (typeof localStorage !== 'undefined') {
+				localStorage.removeItem(key);
+			}
+			store.set(cloneDeep(initialCharacterStoreObject));
+			store.update((store) => {
+				if (!store.merits?.find((e) => e.name === 'Linguistics')) {
+					store.merits = [{ id: generateId(), name: 'Linguistics', value: 0 }];
+				}
+				return store;
+			});
+			attributesPaidWithDotsStore.reset();
+			backgroundPaymentStore.reset();
+			meritPaymentStore.reset();
+			flawPaymentStore.reset();
+		}
+	};
+}

--- a/src/lib/stores/meritPaymentStore.ts
+++ b/src/lib/stores/meritPaymentStore.ts
@@ -1,15 +1,43 @@
 import { generateId } from '$lib/util';
 import { meritName, type MeritName } from '$lib/zod/lotn/enums/meritName';
+import cloneDeep from 'lodash/cloneDeep';
 import { get, type Writable, writable } from 'svelte/store';
 import { z } from 'zod';
 import { characterCreationStore } from './characterCreationStore';
 
 export class MeritPaymentStore {
+	private _initialMeritStoreValues: MeritPaymentStoreEntrySchema[] = [];
+	_meritStoreInternal: Writable<MeritPaymentStoreEntrySchema[]> = writable(
+		cloneDeep(this._initialMeritStoreValues)
+	);
+	private unsubscribe: () => void;
+
 	constructor() {
-		this._meritStoreInternal = writable(meritPaymentStoreEntrySchema.array().parse([]));
+		let initialValue: MeritPaymentStoreEntrySchema[];
+
+		if (typeof localStorage !== 'undefined') {
+			const storedValue = localStorage.getItem('meritPaymentStore');
+			initialValue = storedValue
+				? JSON.parse(storedValue)
+				: cloneDeep(this._initialMeritStoreValues);
+		} else {
+			initialValue = cloneDeep(this._initialMeritStoreValues);
+		}
+
+		this._meritStoreInternal.set(initialValue);
+
+		if (typeof localStorage !== 'undefined') {
+			this.unsubscribe = this._meritStoreInternal.subscribe((value) => {
+				localStorage.setItem('meritPaymentStore', JSON.stringify(value));
+			});
+		} else {
+			this.unsubscribe = () => {};
+		}
 	}
 
-	_meritStoreInternal: Writable<MeritPaymentStoreEntrySchema[]>;
+	destroy() {
+		this.unsubscribe();
+	}
 
 	reset() {
 		this._meritStoreInternal.set([]);

--- a/src/lib/stores/meritPaymentStore.ts
+++ b/src/lib/stores/meritPaymentStore.ts
@@ -11,6 +11,10 @@ export class MeritPaymentStore {
 
 	_meritStoreInternal: Writable<MeritPaymentStoreEntrySchema[]>;
 
+	reset() {
+		this._meritStoreInternal.set([]);
+	}
+
 	addPredatorMerit(name: MeritName, value: number) {
 		const id = generateId();
 		this._meritStoreInternal.update((store) => {
@@ -138,6 +142,39 @@ export class MeritPaymentStore {
 		this._meritStoreInternal.update((store) => {
 			return store.filter((merit) => merit.id !== id);
 		});
+	}
+
+	getMerit(id: string) {
+		return get(this._meritStoreInternal).find((merit) => merit.id === id);
+	}
+
+	getSelectivePaidValues(
+		id: string,
+		{
+			freebies,
+			loresheet,
+			predator,
+			experience
+		}: { freebies: boolean; loresheet: boolean; predator: boolean; experience: boolean }
+	) {
+		const meritInStore = this.getMerit(id);
+		if (!meritInStore) return 0;
+
+		let result = 0;
+		if (freebies) {
+			result += meritInStore.freebies;
+		}
+		if (loresheet) {
+			result += meritInStore.loresheet;
+		}
+		if (predator) {
+			result += meritInStore.predator;
+		}
+		if (experience) {
+			result += meritInStore.xp;
+		}
+
+		return result;
 	}
 }
 

--- a/src/lib/stores/meritPaymentStore.ts
+++ b/src/lib/stores/meritPaymentStore.ts
@@ -40,7 +40,7 @@ export class MeritPaymentStore {
 	}
 
 	reset() {
-		this._meritStoreInternal.set([]);
+		this._meritStoreInternal.set(cloneDeep(this._initialMeritStoreValues));
 	}
 
 	addPredatorMerit(name: MeritName, value: number) {

--- a/src/lib/zod/lotn/playerCharacter/playerCharacterBase.ts
+++ b/src/lib/zod/lotn/playerCharacter/playerCharacterBase.ts
@@ -18,7 +18,7 @@ export const playerCharacterBase = z.object({
 export type PlayerCharacterBase = z.infer<typeof playerCharacterBase>;
 
 export const playerCharacterBaseCreate = z.object({
-	clan: clanName.optional(),
+	clan: clanName.default('Banu Haqim'),
 	generation: z.number().min(9).max(16).default(12),
 	predatorType: predatorType.optional(),
 	bloodPotency: z.number().min(0).max(7).default(1),

--- a/src/lib/zod/lotn/playerCharacter/playerFlaw.ts
+++ b/src/lib/zod/lotn/playerCharacter/playerFlaw.ts
@@ -6,7 +6,7 @@ import { idSchema } from '../util';
 export const playerFlaw = z.object({
 	name: flawName,
 	value: z.number().int().min(0).max(5),
-	description: z.string().max(50).optional(),
+	description: z.string().max(100).optional(),
 	sphereOfInfluence: spheresOfInfluenceName
 		.or(z.literal(''))
 		.default('')

--- a/src/lib/zod/lotn/playerCharacter/playerMerit.ts
+++ b/src/lib/zod/lotn/playerCharacter/playerMerit.ts
@@ -6,7 +6,7 @@ import { idSchema } from '../util';
 export const playerMerit = z.object({
 	name: meritName,
 	value: z.number().int().min(0).max(5),
-	description: z.string().max(50).optional(),
+	description: z.string().max(100).optional(),
 	linkedSkill: z
 		.string()
 		.transform((e) => (e === '' ? undefined : skillName.parse(e)))

--- a/src/lib/zod/lotn/playerCharacter/playerSkill.ts
+++ b/src/lib/zod/lotn/playerCharacter/playerSkill.ts
@@ -6,7 +6,9 @@ export const playerSkill = z.object({
 	name: physicalSkill.or(socialSkill).or(mentalSkill),
 	value: z.number().min(1).max(5),
 	specialization: z
-		.union([z.string().min(1), z.string().max(30)])
+		.string()
+		.min(1)
+		.max(30)
 		.optional()
 		.nullable()
 		.transform((e) => (e === '' ? undefined : e))

--- a/src/routes/lotn/sheet/create/+layout.svelte
+++ b/src/routes/lotn/sheet/create/+layout.svelte
@@ -1,14 +1,42 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import { characterCreationStore } from '$lib/stores/characterCreationStore';
-	import { detectTouchscreen, isDesktopSize } from '$lib/util';
+	import { detectTouchscreen, generateId, isDesktopSize } from '$lib/util';
+	import { onMount } from 'svelte';
 
 	let innerWidth: number = 0;
+
+	onMount(() => {
+		characterCreationStore.update((store) => {
+			if (!store.merits?.find((merit) => merit.name === 'Linguistics')) {
+				if (!store.merits) store.merits = [];
+
+				store.merits.push({
+					id: generateId(),
+					name: 'Linguistics',
+					value: 0
+				});
+			}
+			return store;
+		});
+	});
+
+	function resetStore() {
+		characterCreationStore.clear();
+	}
 </script>
 
 <svelte:window bind:innerWidth />
 
-<h1 class="h1">Character-Creation</h1>
+<div class="flex justify-between">
+	<h1 class="h1">Character-Creation</h1>
+
+	<button class="btn" type="button" on:click={resetStore}>
+		<iconify-icon height="24" icon="mdi:restart" width="24"></iconify-icon>
+		Reset
+	</button>
+</div>
+
 <div
 	class={`mt-4 grid gap-2 ${isDesktopSize(innerWidth) && !detectTouchscreen() ? 'grid-cols-1 sm:grid-cols-[auto_2fr]' : 'grid-cols-1'}`}
 >
@@ -96,6 +124,8 @@
 		</div>
 	{/if}
 	<div class="card rounded-lg p-4">
-		<slot />
+		{#key $characterCreationStore}
+			<slot />
+		{/key}
 	</div>
 </div>

--- a/src/routes/lotn/sheet/create/step_02/+page.svelte
+++ b/src/routes/lotn/sheet/create/step_02/+page.svelte
@@ -7,7 +7,10 @@
 
 	onMount(() => {
 		if (!$characterCreationStore.clan) {
-			$characterCreationStore.clan = 'Banu Haqim';
+			characterCreationStore.update((store) => {
+				store.clan = 'Banu Haqim';
+				return store;
+			});
 		}
 	});
 

--- a/src/routes/lotn/sheet/create/step_03/+page.svelte
+++ b/src/routes/lotn/sheet/create/step_03/+page.svelte
@@ -6,12 +6,12 @@
 	import { flawPaymentStore } from '$lib/stores/flawPaymentStore';
 	import { meritPaymentStore } from '$lib/stores/meritPaymentStore';
 	import { onMount } from 'svelte';
-	import { get } from 'svelte/store';
+	import { get, writable } from 'svelte/store';
 
 	const validGenerations = [9, 10, 11, 12, 13, 14, 15, 16];
-	$: selectedGeneration = 16;
-	$: selectedBloodPotency = 0;
-	$: selectedBloodPotencyConfig = getBloodPotencies(selectedGeneration);
+	const selectedGeneration = writable(get(characterCreationStore).generation);
+	$: selectedBloodPotency = get(characterCreationStore).bloodPotency;
+	$: selectedBloodPotencyConfig = getBloodPotencies($selectedGeneration);
 
 	const validBloodPotencyPerGeneration: { [k: number]: { min: number; max: number } } = {
 		9: { min: 2, max: 5 },
@@ -33,17 +33,17 @@
 		if (!$characterCreationStore.clan) {
 			$characterCreationStore.clan = 'Banu Haqim';
 		}
-		selectedBloodPotency = $characterCreationStore.bloodPotency;
-		selectedGeneration = $characterCreationStore.generation;
+
+		selectedGeneration.set($characterCreationStore.generation);
 	});
 
 	function updateGeneration() {
 		characterCreationStore.update((store) => {
-			store.generation = selectedGeneration;
+			store.generation = $selectedGeneration;
 			return store;
 		});
 
-		selectedBloodPotency = validBloodPotencyPerGeneration[selectedGeneration].min;
+		selectedBloodPotency = validBloodPotencyPerGeneration[$selectedGeneration].min;
 		updateBloodPotency();
 	}
 
@@ -82,11 +82,11 @@
 			<span>Generation</span>
 			<select
 				class="select rounded-lg"
-				bind:value={selectedGeneration}
+				bind:value={$selectedGeneration}
 				on:change={updateGeneration}
 			>
 				{#each validGenerations as generation}
-					<option selected={selectedGeneration === generation} value={generation}>
+					<option selected={$selectedGeneration === generation} value={generation}>
 						{generation}
 					</option>
 				{/each}
@@ -126,9 +126,7 @@
 	</div>
 {/if}
 {#if $characterCreationStore.clan !== 'Thin-Blooded' || ($characterCreationStore.clan === 'Thin-Blooded' && $characterCreationStore.merits?.some((e) => e.name === 'Catenating Blood'))}
-	<Checkbox checked={get(characterCreationStore).ghoul} onChange={updateGhoulStatus}>
-		Ghoul
-	</Checkbox>
+	<Checkbox checked={$characterCreationStore.ghoul} onChange={updateGhoulStatus}>Ghoul</Checkbox>
 {/if}
 {#if !$characterCreationStore.ghoul}
 	<div class="mb-4 mt-2 grid auto-rows-auto grid-cols-1 gap-2 sm:grid-cols-4">

--- a/src/routes/lotn/sheet/create/step_04/+page.svelte
+++ b/src/routes/lotn/sheet/create/step_04/+page.svelte
@@ -12,14 +12,6 @@
 	import { Ratings } from '@skeletonlabs/skeleton';
 
 	let selectedAttribute: AttributeName | undefined = undefined;
-	$: amount4Dots = attributesPaidWithDotsStore.amount4Dots;
-	$: max4Dots = attributesPaidWithDotsStore.max4Dots;
-	$: amount3Dots = attributesPaidWithDotsStore.amount3Dots;
-	$: max3Dots = attributesPaidWithDotsStore.max3Dots;
-	$: amount2Dots = attributesPaidWithDotsStore.amount2Dots;
-	$: max2Dots = attributesPaidWithDotsStore.max2Dots;
-	$: amount1Dots = attributesPaidWithDotsStore.amount1Dots;
-	$: max1Dots = attributesPaidWithDotsStore.max1Dots;
 
 	let spendingPoints: AttributeDotCategory = 4;
 
@@ -163,21 +155,25 @@
 <hr class="mt-4" />
 <div class="col-span-2 grid grid-cols-2 gap-2 p-2 sm:grid-cols-4">
 	<div>
-		Used 4 dots: {$amount4Dots}/{$max4Dots}
+		Used 4 dots: {$attributesPaidWithDotsStore[4].attributeNames
+			.length}/{attributesPaidWithDotsStore.max4Dots}
 	</div>
 	<div>
-		Used 3 dots: {$amount3Dots}/{$max3Dots}
+		Used 3 dots: {$attributesPaidWithDotsStore[3].attributeNames
+			.length}/{attributesPaidWithDotsStore.max3Dots}
 	</div>
 	<div>
-		Used 2 dots: {$amount2Dots}/{$max2Dots}
+		Used 2 dots: {$attributesPaidWithDotsStore[2].attributeNames
+			.length}/{attributesPaidWithDotsStore.max2Dots}
 	</div>
 	<div>
-		Used 1 dots: {$amount1Dots}/{$max1Dots}
+		Used 1 dots: {$attributesPaidWithDotsStore[1].attributeNames
+			.length}/{attributesPaidWithDotsStore.max1Dots}
 	</div>
 </div>
 <div class="col-span-2 grid grid-cols-2 gap-2 p-2 sm:grid-cols-4">
 	<div class="flex flex-col gap-2">
-		{#each attributesPaidWithDotsStore.store[4].attributeNames.sort() as attribute}
+		{#each $attributesPaidWithDotsStore[4].attributeNames as attribute}
 			<EditableAttribute
 				attributeName={attribute}
 				attributeValue={4}
@@ -188,7 +184,7 @@
 		{/each}
 	</div>
 	<div class="flex flex-col gap-2">
-		{#each attributesPaidWithDotsStore.store[3].attributeNames.sort() as attribute}
+		{#each $attributesPaidWithDotsStore[3].attributeNames as attribute}
 			<EditableAttribute
 				attributeName={attribute}
 				attributeValue={3}
@@ -199,7 +195,7 @@
 		{/each}
 	</div>
 	<div class="flex flex-col gap-2">
-		{#each attributesPaidWithDotsStore.store[2].attributeNames.sort() as attribute}
+		{#each $attributesPaidWithDotsStore[2].attributeNames as attribute}
 			<EditableAttribute
 				attributeName={attribute}
 				attributeValue={2}
@@ -210,7 +206,7 @@
 		{/each}
 	</div>
 	<div class="flex flex-col gap-2">
-		{#each attributesPaidWithDotsStore.store[1].attributeNames.sort() as attribute}
+		{#each $attributesPaidWithDotsStore[1].attributeNames as attribute}
 			<EditableAttribute attributeName={attribute} attributeValue={1} displayStyle="dots" />
 		{/each}
 	</div>

--- a/src/routes/lotn/sheet/create/step_07/+page.svelte
+++ b/src/routes/lotn/sheet/create/step_07/+page.svelte
@@ -716,7 +716,7 @@
 								{#key $paymentStore.backgrounds.filter((entry) => entry.name === pointsRecordEntry.name)}
 									{#if Array.isArray(pointsRecordEntry.name)}
 										<li>
-											<span class="flex gap-1">
+											<span class="flex gap-2 whitespace-nowrap">
 												{#each pointsRecordEntry.name as key, index}
 													<HelpText id={key}>
 														{key}{index !== pointsRecordEntry.name.length - 1 ? ' / ' : ': '}
@@ -736,7 +736,7 @@
 									{:else if pointsRecordEntry.name}
 										{#key $paymentStore.backgrounds.filter((entry) => entry.name === pointsRecordEntry.name)}
 											<li>
-												<span class="flex gap-2">
+												<span class="flex gap-2 whitespace-nowrap">
 													<HelpText id={pointsRecordEntry.name}>
 														{pointsRecordEntry.name}:
 														<svelte:fragment slot="helpText">

--- a/src/routes/lotn/sheet/create/step_10/+page.svelte
+++ b/src/routes/lotn/sheet/create/step_10/+page.svelte
@@ -45,7 +45,9 @@
 		getValidMerits,
 		hasBeenGrantedByLoresheet,
 		hasBeenPaidWithDots,
-		hasThinBloodAlchemyMerit
+		hasMultipleMeritLevels,
+		hasThinBloodAlchemyMerit,
+		isPredatorMerit
 	} from '$lib/components/lotn/util/meritUtil';
 	import { ScreenSize } from '$lib/sceenSize';
 	import { attributesPaidWithDotsStore } from '$lib/stores/attributesPaidWithDotsStore';
@@ -54,6 +56,7 @@
 		characterCreationStore
 	} from '$lib/stores/characterCreationStore';
 	import { disciplineFreebieStore } from '$lib/stores/disciplineFreebieStore';
+	import { meritPaymentStore } from '$lib/stores/meritPaymentStore';
 	import { skillsPaidWithDotsStore } from '$lib/stores/skillsPaidWithDotsStore';
 	import { generateId, isNotNullOrUndefined } from '$lib/util';
 	import type { ThinBloodAlchemy } from '$lib/zod/lotn/disciplines/thinBloodAlchemy';
@@ -663,7 +666,7 @@
 			const index = store.merits.findIndex((m) => m.id === event.detail.id);
 			if (index === -1) return store;
 
-			store.merits[index].description = event.detail.description;
+			store.merits[index].description = event.detail.description?.replace(/[\r\n]+/g, ' ');
 
 			return store;
 		});
@@ -1581,13 +1584,23 @@
 			{/each}
 		</div>
 	{:else if selectedKindIncreaseOption === 'Merit' && $characterCreationStore.merits && $characterCreationStore.merits.length > 0}
-		<div class="grid grid-cols-1 grid-rows-1 gap-2 sm:grid-cols-3">
+		<div class="grid grid-cols-1 grid-rows-1 gap-2 sm:grid-cols-4">
 			{#each $characterCreationStore.merits as merit}
 				<EditableMerit
-					enableEditValue={getApplicableMeritLevels(merit.name).length > 1}
+					displayFormat="column"
+					enableEditLinkedSkill={true}
+					enableEditValue={hasMultipleMeritLevels(merit.name)}
 					{merit}
-					showDeleteButton={!hasBeenPaidWithDots(merit) && !hasBeenGrantedByLoresheet(merit)}
+					showDeleteButton={!isPredatorMerit(merit) &&
+						!hasBeenPaidWithDots(merit) &&
+						!hasBeenGrantedByLoresheet(merit)}
 					showDescriptionInput={displaySpecificMeritDescription(merit)}
+					startValue={meritPaymentStore.getSelectivePaidValues(merit.id, {
+						freebies: true,
+						loresheet: true,
+						predator: true,
+						experience: false
+					})}
 					on:linkedSkillChange={(e) => updateMeritLinkedSkill(e)}
 					on:descriptionChange={(e) => updateMeritDescription(e)}
 					on:valueChange={(e) => updateMeritValue(e)}

--- a/src/routes/lotn/sheet/create/step_11/+page.svelte
+++ b/src/routes/lotn/sheet/create/step_11/+page.svelte
@@ -28,6 +28,7 @@
 				if (result.success) {
 					submitting = false;
 					characterStore.set(result.data);
+					characterCreationStore.clear();
 					goto(`${base}/lotn/sheet/${result.data.id}`, { replaceState: true });
 				} else {
 					responseMessage = JSON.stringify(result.error.errors, undefined, 2);


### PR DESCRIPTION
- Die Daten des Charaktereditors werden jetzt bis zum erfolgreichen Speichern in der LocalStorage zwischengespeichert
- Ein Reset-Button wurde ins Editor-Layout eingefügt um diesen LocalStorage-Eintrag auf Default und sämtliche Daten-Stores der Anwendung zurückzusetzen
- Beim Laden des Editors bzw. dem Reset wird einmalig Linguistics 0 hinzugefügt
- Merits/Flaws können jetzt (sofern variable Werte erlaubt sind) direkt auf der Komponente editiertwerden und müssen nicht wie bisher zuerst entfernt werden bevor sie mit dem neuen Wert hinzugefügt werden
- Die Description-Felder bei Merits und Flaws sind jetzt Textarea-Felder statt Text-Inputs (und damit mehrzeilig)
- Allgemeine Refactors im Code