### PR TITLE
Feature/haven-freebies

### DIFF
--- a/src/lib/components/lotn/characterSheet/components/BackgroundDisadvantage/BackgroundDisadvantage.svelte
+++ b/src/lib/components/lotn/characterSheet/components/BackgroundDisadvantage/BackgroundDisadvantage.svelte
@@ -175,7 +175,7 @@
 			disabled={!backgroundPaymentStore.canRemoveBackgroundDisadvantage(
 				disadvantage.value,
 				$paymentStore.backgrounds.reduce((acc, entry) => acc + entry.freebies, 0),
-				$paymentStore.associatedAdvantage.reduce((acc, entry) => acc + entry.freebies, 0)
+				$paymentStore.associatedAdvantages.reduce((acc, entry) => acc + entry.freebies, 0)
 			)}
 			type="button"
 			on:click={() => {

--- a/src/lib/components/lotn/util/loresheetUtil.ts
+++ b/src/lib/components/lotn/util/loresheetUtil.ts
@@ -25,3 +25,11 @@ export function checkForMerits(loresheet: LoresheetName, level: 'level1' | 'leve
 		(e) => e.kind === 'Merit' && meritName.safeParse(e.name).success
 	);
 }
+
+export function getLoresheetChanges(
+	loresheet: LoresheetName,
+	kind: 'Background' | 'Merit' | 'Skill',
+	level: 'level1' | 'level2' | 'level3'
+) {
+	return (loresheetConfig[loresheet][level].changes ?? []).filter((e) => e.kind === kind);
+}

--- a/src/lib/stores/characterCreationStore.ts
+++ b/src/lib/stores/characterCreationStore.ts
@@ -7,6 +7,7 @@ import {
 	type BackgroundAdvantageName
 } from '$lib/zod/lotn/enums/backgroundAdvantageName';
 import { backgroundName, type BackgroundName } from '$lib/zod/lotn/enums/backgroundName';
+import { skillName, type SkillName } from '$lib/zod/lotn/enums/skillName';
 import type { SpheresOfInfluenceName } from '$lib/zod/lotn/enums/spheresOfInfluenceName';
 import type { PlayerBackgroundAdvantage } from '$lib/zod/lotn/playerCharacter/playerBackgroundAdvantage';
 import { playerCharacterCreate } from '$lib/zod/lotn/playerCharacter/playerCharacter';
@@ -50,7 +51,13 @@ const paymentStoreSchema = z.object({
 			value: z.literal(1).or(z.literal(2)).or(z.literal(3))
 		})
 		.array(),
-	associatedAdvantages: paymentStoreAdvantageEntrySchema.array()
+	associatedAdvantages: paymentStoreAdvantageEntrySchema.array(),
+	skills: z
+		.object({
+			name: skillName,
+			value: z.number()
+		})
+		.array()
 });
 type PaymentStoreSchema = z.infer<typeof paymentStoreSchema>;
 
@@ -58,7 +65,8 @@ export class BackgroundPaymentStore {
 	private _initialPaymentStoreValues: PaymentStoreSchema = {
 		backgrounds: [],
 		associatedAdvantages: [],
-		loresheet: []
+		loresheet: [],
+		skills: []
 	};
 	private _paymentStoreInternal: Writable<PaymentStoreSchema> = writable(
 		cloneDeep(this._initialPaymentStoreValues)
@@ -729,6 +737,7 @@ export class BackgroundPaymentStore {
 
 				if (updatedArray) {
 					return {
+						...store,
 						backgrounds: updatedArray,
 						associatedAdvantages: updatedArrayAdvantages,
 						loresheet: store.loresheet
@@ -1225,6 +1234,28 @@ export class BackgroundPaymentStore {
 
 			return store;
 		});
+	}
+
+	addSkill(skill: SkillName, value: number) {
+		this.paymentStore.update((store) => {
+			store.skills.push({ name: skill, value: value });
+			return store;
+		});
+	}
+
+	removeSkill(skill: SkillName) {
+		this.paymentStore.update((store) => {
+			store.skills = store.skills.filter((entry) => entry.name !== skill);
+			return store;
+		});
+	}
+
+	getSkillValue(skill: SkillName) {
+		return get(this._paymentStoreInternal).skills.find((entry) => entry.name === skill)?.value;
+	}
+
+	includesSkill(skill: SkillName) {
+		return get(this._paymentStoreInternal).skills.some((entry) => entry.name === skill);
 	}
 }
 

--- a/src/lib/stores/characterCreationStore.ts
+++ b/src/lib/stores/characterCreationStore.ts
@@ -567,7 +567,8 @@ export class BackgroundPaymentStore {
 		const freebiePointsLeft =
 			get(this._maxFreebiePointsInternal) -
 			backgrounds.reduce((acc, entry) => acc + entry.freebies, 0) -
-			associatedAdvantage.reduce((acc, entry) => acc + entry.freebies, 0);
+			associatedAdvantage.reduce((acc, entry) => acc + entry.freebies, 0) -
+			(get(characterCreationStore).loresheet?.values?.reduce((acc, entry) => acc + entry, 0) ?? 0);
 
 		const existingEntry = backgrounds.find((entry) => entry.id === id);
 

--- a/src/routes/lotn/sheet/create/+layout.svelte
+++ b/src/routes/lotn/sheet/create/+layout.svelte
@@ -127,8 +127,6 @@
 		</div>
 	{/if}
 	<div class="card rounded-lg p-4">
-		{#key $characterCreationStore}
-			<slot />
-		{/key}
+		<slot />
 	</div>
 </div>

--- a/src/routes/lotn/sheet/create/step_05/+page.svelte
+++ b/src/routes/lotn/sheet/create/step_05/+page.svelte
@@ -2,7 +2,10 @@
 	import EditableSkill from '$lib/components/lotn/EditableSkill/EditableSkill.svelte';
 	import { getSkillHelptext, hasSkillSpecializations } from '$lib/components/lotn/util/skillUtil';
 	import { ScreenSize } from '$lib/sceenSize';
-	import { characterCreationStore } from '$lib/stores/characterCreationStore';
+	import {
+		backgroundPaymentStore,
+		characterCreationStore
+	} from '$lib/stores/characterCreationStore';
 	import { skillsPaidWithDotsStore } from '$lib/stores/skillsPaidWithDotsStore';
 	import { generateId } from '$lib/util';
 	import { skillDotCategory, type SkillDotCategory } from '$lib/zod/lotn/enums/skillDotsCategory';
@@ -174,7 +177,9 @@
 						>
 							<option disabled selected value="">Select a Skill</option>
 							{#each getAvailableSkills() as skill}
-								<option value={skill}>{skill}</option>
+								<option disabled={backgroundPaymentStore.includesSkill(skill)} value={skill}>
+									{skill}
+								</option>
 							{/each}
 						</select>
 					{/key}

--- a/src/routes/lotn/sheet/create/step_10/+page.svelte
+++ b/src/routes/lotn/sheet/create/step_10/+page.svelte
@@ -1559,8 +1559,13 @@
 					displayStyle="dots"
 					displayValue="beside"
 					editModeEnabled={true}
-					minValue={skillsPaidWithDotsStore.getSkillsPaidWithDotsByName(skill.name) ?? 1}
-					showDeleteButton={!skillsPaidWithDotsStore.hasSkillBeenPaidWithDots(skill.name)}
+					minValue={skillsPaidWithDotsStore.getSkillsPaidWithDotsByName(skill.name)
+						? skillsPaidWithDotsStore.getSkillsPaidWithDotsByName(skill.name)
+						: backgroundPaymentStore.getSkillValue(skill.name)
+							? backgroundPaymentStore.getSkillValue(skill.name)
+							: 1}
+					showDeleteButton={!skillsPaidWithDotsStore.hasSkillBeenPaidWithDots(skill.name) &&
+						!backgroundPaymentStore.includesSkill(skill.name)}
 					{skill}
 					on:valueChange={updateSkill}
 					on:specializationChange={updateSkillSpecialization}


### PR DESCRIPTION
## Loresheet Skillboni hinzugefügt
- Skill Boni von Loresheets werden jetzt automatisch hinzugefügt (z.B. High Clan -> Peacock)
- Diese Skills können nur über Abwahl der Loresheet-Stufe gelöscht werden
- Diese Skills werden nicht in Schritt 5 angezeigt (weil keine Freebie-Punkte auf sie verteilt wurden
- Durch Loresheets hinzugefügte Skills ersetzen ggfs. bereits gewählte Skills in Schritt 5 ersetzt
- Durch Loresheets hinzugefügte Skills werden in Schritt 5 ausgegraut und können nicht als Freebie-Punkt-Ziele gewählt werden
- Durch Loresheet hinzugefügte Skills können ganz normal in Schritt 10 gesteigert werden, können aber nie unter den initialen Wert sinken
## Haven Freebies hinzugefügt
- Haven der Stufe 2 und 3 geben jetzt jeweils den zugehörigen Freebie-Punkt für Haven-Advantages
## Korrektur der nervöse Zuckungen des Content-Bereichs
- Der Contentbereich wird nicht mehr bei jeder Änderung im characterCreationStore neu erzeugt
## Korrektur von Loresheet Background Boni
- Wenn ein Loresheet wie z.B. High Clan -> Friends in High Places Boni auf mehrere Hintergründe gibt wird die Obergrenze jetzt korrekt geprüft
- Zuvor wurden dort enthaltene Boni nicht respektiert, wenn es nicht der gerade editierte Hintergrund war
- Gewählte Loresheet-Stufen werden jetzt in die Rechnung der noch verfügbaren Freebie-Punkte mit einbezogen