### PR TITLE
fix: user role kann in der datenbank leer bleiben

### DIFF
--- a/src/lib/zod/user.spec.ts
+++ b/src/lib/zod/user.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { pbUser } from './user';
+
+describe('user defaults', () => {
+	it('an default user without a role should work', () => {
+		const emptyObject = {
+			avatar: '',
+			collectionId: '12345',
+			email: 'demo@test.de',
+			id: '12345',
+			name: 'testi',
+			username: 'testi',
+			role: ''
+		};
+		const user = pbUser.safeParse(emptyObject);
+		expect(user.success).toBe(true);
+	});
+});

--- a/src/lib/zod/user.ts
+++ b/src/lib/zod/user.ts
@@ -8,7 +8,7 @@ export const pbUser = z.object({
 	name: z.string(),
 	avatar: z.string(),
 	collectionId: z.string(),
-	role: roleName
+	role: z.string().transform((e) => (e === '' ? roleName.parse('User') : roleName.parse(e)))
 });
 
 export type PBUser = z.infer<typeof pbUser>;


### PR DESCRIPTION
- Die Rolle eines Users kann / muss in der Datenbank leer sein können, weil bei OAuth keine Default-Rolle mitgeben kann
- Leere Rollen werden automatisch wie "User" verwendet