### PR TITLE
fix: Default-Rollen für OAuth2 Anmeldungen hinzugefügt

### DIFF
--- a/src/lib/zod/user.spec.ts
+++ b/src/lib/zod/user.spec.ts
@@ -10,7 +10,7 @@ describe('user defaults', () => {
 			id: '12345',
 			name: 'testi',
 			username: 'testi',
-			role: ''
+			role: 'User'
 		};
 		const user = pbUser.safeParse(emptyObject);
 		expect(user.success).toBe(true);

--- a/src/lib/zod/user.ts
+++ b/src/lib/zod/user.ts
@@ -8,7 +8,7 @@ export const pbUser = z.object({
 	name: z.string(),
 	avatar: z.string(),
 	collectionId: z.string(),
-	role: z.string().transform((e) => (e === '' ? roleName.parse('User') : roleName.parse(e)))
+	role: roleName
 });
 
 export type PBUser = z.infer<typeof pbUser>;

--- a/src/routes/redirect/+server.ts
+++ b/src/routes/redirect/+server.ts
@@ -37,7 +37,8 @@ export const GET: RequestHandler = async ({ locals, url, cookies }: RequestEvent
 			`${url.origin}/redirect`,
 			// pass optional user create data
 			{
-				emailVisibility: false
+				emailVisibility: false,
+				role: 'User'
 			}
 		);
 


### PR DESCRIPTION
- Redact last statement: Default-Rollen können beim routen via /redirect hinzugefügt werden