### PR TITLE
bugfix: projektname in objekt zur datenbank-übertragung aufgenommen

### DIFF
--- a/src/lib/zod/lotn/playerCharacter/playerCharacterBase.ts
+++ b/src/lib/zod/lotn/playerCharacter/playerCharacterBase.ts
@@ -40,7 +40,8 @@ export const playerCharacterBaseCreateRequestBody = z.object({
 	sect: sectName,
 	status: characterStatus.readonly(),
 	ghoul: z.boolean(),
-	name: z.string().min(1).max(30)
+	name: z.string().min(1).max(30),
+	project: projectName
 });
 export type PlayerCharacterBaseCreateRequestBody = z.infer<
 	typeof playerCharacterBaseCreateRequestBody


### PR DESCRIPTION
- bislang fehlte project als feld in dem objekt, wurde jetzt nachgetragen