### PR TITLE
bugfix: Frühzeitiger Return bei Experience-Verteilung korrigiert

### DIFF
--- a/src/routes/lotn/admin/+page.server.ts
+++ b/src/routes/lotn/admin/+page.server.ts
@@ -143,8 +143,6 @@ export const actions: Actions = {
 							message: `Failed to add xp to character with id ${characterId}`
 						});
 					}
-
-					return { success: true };
 				} catch (e) {
 					return fail(500, { message: 'Failed to process request' });
 				}


### PR DESCRIPTION
- Bislang wurde nach dem ersten erfolgreichen Exp-Eintrag im Admin-Menü augehört, jetzt wird die gesamte Liste (wenn möglich) abgearbeitet